### PR TITLE
Context menu fix

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,5 +1,5 @@
 [
-    { "command": "gist", "caption": "Create Public Gist" }
-    { "command": "gist_private", "caption": "Create Private Gist" }
+    { "command": "gist", "caption": "Create Public Gist" },
+    { "command": "gist_private", "caption": "Create Private Gist" },
     { "command": "gist_list", "caption": "Get Gist List" }
 ]


### PR DESCRIPTION
Plugin commands were not showing up in context menu, due to missing dashes in commands array
