### PR TITLE
Add support for token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ Go to the "Packages" directory (`Preferences` / `Browse Packages…`). Then clon
 
 # Options
 
-If you're using OS X and have a keychain entry for github.com, no configuration is needed. Otherwise, edit the settings file (it should open automatically the first time you use a Gist command):
+If you're using OS X and have a keychain entry for github.com, no configuration is needed. Otherwise, edit the settings file (it should open automatically the first time you use a Gist command). Note you must specifiy either username AND password or token.
 
 *   `"username": ""`
 
-    You need to enter your GitHub username here
+    You can enter your GitHub username here
 
 *   `"password": ""`
 
-    You need to enter your GitHub password here
+    You can enter your GitHub password here
+
+*   `"token": ""`
+
+    You can enter your GitHub token here. To generate a token, see "Generating Access Tokens"
 
 *   `"https_proxy": http://user:pass@proxy:port`
 
@@ -85,6 +89,23 @@ Use the `Gist` / `Add File To Gist` command to see a list of your Gists. Selecti
 
 * Windows and Linux: "ctrl+shift+alt+g"
 * OS X: "ctrl+shift+super+g"
+
+# Generating Access Token
+Adapted from [here](https://github.com/bgreenlee/sublime-github#generating-your-own-access-token)
+Open up a Terminal window/shell (on OS X, Linux or Cygwin), and run:
+
+    curl -u username -d '{"scopes":["gist"]}' https://api.github.com/authorizations
+
+where `username` is your GitHub username. You'll be prompted for your password first. Then you'll get back
+a response that includes a 40-digit "token" value (e.g. `6423ba8429a152ff4a7279d1e8f4674029d3ef87`).
+Go to Sublime Text 2 -> Preferences -> Package Settings -> Gist -> Settings - User,
+and insert the token there. It should look like:
+
+    {
+        "token": "6423ba8429a152ff4a7279d1e8f4674029d3ef87"
+    }
+
+Restart Sublime.
 
 # Information
 

--- a/gist.py
+++ b/gist.py
@@ -44,6 +44,9 @@ class SimpleHTTPError(Exception):
         self.code = code
         self.response = response
 
+class MissingTokenException(Exception):
+    pass
+
 def get_credentials():
     username = settings.get('username')
     password = settings.get('password')
@@ -53,6 +56,16 @@ def get_credentials():
 
 def basic_auth_string():
     auth_string = u'%s:%s' % get_credentials()
+    return auth_string.encode('utf-8')
+
+def get_token():
+    token = settings.get('token')
+    if not token:
+        raise MissingTokenException()
+    return token
+
+def token_auth_string():
+    auth_string = u'%s' % get_token()
     return auth_string.encode('utf-8')
 
 if sublime.platform() == 'osx':
@@ -246,7 +259,10 @@ def api_request_native(url, data=None, method=None):
     request = urllib2.Request(url)
     if method:
         request.get_method = lambda: method
-    request.add_header('Authorization', 'Basic ' + base64.urlsafe_b64encode(basic_auth_string()))
+    try:
+        request.add_header('Authorization', 'token ' + token_auth_string())
+    except MissingTokenException:
+        request.add_header('Authorization', 'Basic ' + base64.urlsafe_b64encode(basic_auth_string()))
     request.add_header('Accept', 'application/json')
     request.add_header('Content-Type', 'application/json')
 
@@ -329,7 +345,10 @@ class GistCommand(sublime_plugin.TextCommand):
 
     @catch_errors
     def run(self, edit):
-        get_credentials()
+        try:
+            get_token()
+        except MissingTokenException:
+            get_credentials()
         regions = [region for region in self.view.sel() if not region.empty()]
 
         if len(regions) == 0:


### PR DESCRIPTION
Some quick work to support authentication via tokens, rather than using plaintext stored username/password. Addresses existing [issue #14](https://github.com/condemil/Gist/issues/14).
