### PR TITLE
Add user setting to limit the Gists displayed in "Open Gist"

### DIFF
--- a/Gist.sublime-settings
+++ b/Gist.sublime-settings
@@ -17,5 +17,8 @@
 	"url": "",
 
 	// Max Gists to show (max 100 allowed by GitHub API)
-	"max_gists": 100
+	"max_gists": 100, 
+
+	// Limit to gists with specific prefix
+	"gist_prefix": "Snippet:"
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ If you're using OS X and have a keychain entry for github.com, no configuration 
 
 	Set the maximum number of Gists that can will fetched by the plugin. It can't be higher than 100, because of GitHub API limitations.
 
+* `"gist_prefix": ""`
+
+	Limit the Gists displayed in the `Open Gist` list by prefix. Leave blank to display all Gists. Example: `"gist_prefix": "Snippet:"` will only list Gists with names starting with the text **Snippet:**.
+
 # Usage
 
 All functionality of the plugin is available in the `Tools` / `Gist` menu and in the command pallette.

--- a/gist.py
+++ b/gist.py
@@ -12,6 +12,7 @@ import tempfile
 import traceback
 import contextlib
 import shutil
+import re
 
 DEFAULT_CREATE_PUBLIC_VALUE = 'false'
 DEFAULT_USE_PROXY_VALUE = 'false'
@@ -469,6 +470,10 @@ class GistListCommandBase(object):
     def run(self, *args):
         gists = get_gists()
         gist_names = [gist_title(gist) for gist in gists]
+        if settings.get('gist_prefix'):
+            prefix_pattern = "^%s" % (settings.get('gist_prefix'))
+            gist_names = filter (lambda a: re.search(prefix_pattern, a), gist_names)
+        print gist_names
 
         def on_gist_num(num):
             if num != -1:


### PR DESCRIPTION
Add user setting to limit the Gists displayed in the `Open Gist` list by prefix.
