### PR TITLE
Updating Gist on cmd + s

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,7 +1,9 @@
 [
+	{ "keys": ["super+s"], "command": "gist_update_file", "context":
+		[{ "key": "setting.isGist", "operator": "equal", "operand": true }]
+	},
 	{ "keys": ["super+k", "super+i"], "command": "gist" },
 	{ "keys": ["super+k", "super+p"], "command": "gist_private" },
-	{ "keys": ["super+k", "super+s"], "command": "gist_update_file" },
 	{ "keys": ["super+k", "super+o"], "command": "gist_list" },
 	{ "keys": ["super+k", "super+["], "command": "insert_gist_list" },
 	{ "keys": ["super+k", "super+]"], "command": "gist_add_file" }

--- a/gist.py
+++ b/gist.py
@@ -240,6 +240,10 @@ def open_gist(gist_url):
         edit = view.begin_edit()
         view.insert(edit, 0, gist['files'][gist_filename]['content'])
         view.end_edit(edit)
+
+        #MYCODE
+        view.settings().set("isGist", True)
+        #/MYCODE
         if not "language" in locals(): continue
         language = gist['files'][gist_filename]['language']        
         new_syntax = os.path.join(language,"{0}.tmLanguage".format(language))


### PR DESCRIPTION
It would be nice to update the gist in save instead of saving it to the local disk.

This can be done adding the following keybinding in the defaults keymaps in this case the OSX one:

``` json
{ "keys": ["super+s"], "command": "gist_update_file", "context":
  [{ "key": "setting.isGist", "operator": "equal", "operand": true }]
}
```

and the following in the `open_gist` method inside gist.py:

``` python
        view.settings().set("isGist", True)
```

This is the whole change in the pull request.
