### PR TITLE
Display file name instead of description for 'open gist' menu

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -288,8 +288,7 @@ def get_user_gists(user):
     return api_request(USER_GISTS_URL % user)
 
 def gist_title(gist):
-    files = gist.get('files')
-    file_name = list(files)
+    file_name = sorted(gist['files'].keys())
     title = file_name[0] or gist.get('id')
 
     if settings.get('show_authors'):


### PR DESCRIPTION
I carefully craft my gist titles, so it was counterproductive for the 'open gist' menu to only show descriptions. 

The Gist API returns the file name inside a dictionary, so first .get('files'.
Then list() the files dict, which returns an array with 1 entry.
Finally, replaced 'description' with file_name[0]

I am submitting this as a pull for the main repo because I assume this is the intended behavior. If not maybe this functionality could be included as a config option?
