### PR TITLE
Users/Orgs for Quick Panel should also be an array of strings

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -296,7 +296,7 @@ def gists_filter(all_gists):
         if not gist['files']:
             continue
 
-        if prefix: 
+        if prefix:
             if name[0][0:prefix_len] == prefix:
                 name[0] = name[0][prefix_len:] # remove prefix from name
             else:
@@ -592,7 +592,7 @@ class GistListCommandBase(object):
 
         if settings.get('include_users'):
             self.users = list(settings.get('include_users'))
-            gist_names = ["> " + user for user in self.users] + gist_names
+            gist_names = [["> " + user] for user in self.users] + gist_names
 
         if settings.get('include_orgs'):
             if settings.get('include_orgs') == True:
@@ -600,7 +600,7 @@ class GistListCommandBase(object):
             else:
                 self.orgs = settings.get('include_orgs')
 
-            gist_names = ["> " + org for org in self.orgs] + gist_names
+            gist_names = [["> " + org] for org in self.orgs] + gist_names
 
         # print(gist_names)
 


### PR DESCRIPTION
Having something like this (in plugin settings): `"include_orgs": ["wat"]`
I've got this error:

```
Traceback (most recent call last):
  File "Library/Application Support/Sublime Text 3/Packages/Gist/gist.py", line 103, in _fn
    return fn(*args, **kwargs)
  File "Library/Application Support/Sublime Text 3/Packages/Gist/gist.py", line 638, in run
    self.get_window().show_quick_panel(gist_names, on_gist_num)
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime.py", line 355, in show_quick_panel
    items_per_row, on_select, on_highlight, flags, selected_index)
TypeError: String required
error: Gist: unknown error (please, report a bug!)
```

This PR solves this issue by suppling org/users as an array of string - like other gists are.
