### PR TITLE
modified allowed file formats

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -189,8 +189,10 @@ def open_gist(gist_url):
     files = sorted(gist['files'].keys())
 
     for gist_filename in files:
-        # if gist['files'][gist_filename]['type'].split('/')[0] != 'text':
-        #    continue
+        allowedTypes = ['text', 'application']
+        type = gist['files'][gist_filename]['type'].split('/')[0]
+        if type not in allowedTypes:
+           continue
 
         view = sublime.active_window().new_file()
 


### PR DESCRIPTION
improves on the fix for #105 without raising #92

this fix prevents binary types such as images from being opened.
Only opens files of type `text/*` and `application/*`
Handling files of type `application/*` is necessary to open javascript, xml, etc...
