### PR TITLE
Added plugin_loaded to fix an issue that it cannot read the setting file...

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -24,6 +24,12 @@ else:
     from helpers import *
 
 
+def plugin_loaded():
+    settings.loaded_settings = sublime.load_settings('Gist.sublime-settings')
+    settings.get = settings.loaded_settings.get
+    settings.set = settings.loaded_settings.set
+
+
 def catch_errors(fn):
     @functools.wraps(fn)
     def _fn(*args, **kwargs):


### PR DESCRIPTION
It used to work before, but after some updates on this plugin, loading setting doesn't work anymore in ST3. The issue was that it reads the setting file before the plugin is actually loaded, resulting in the setting variable is None. So, I have added plugin_loaded method to update the settings.loaded_settings, get, and set attributes. I have tested it in my ST3 and work fine. Pls. consider to apply it to your master branch. Thanks,
