### PR TITLE
Fixes issue #124 odd auto_indent on gist insert

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -118,12 +118,22 @@ def insert_gist(gist_url):
     gist = api_request(gist_url)
     files = sorted(gist['files'].keys())
 
+
     for gist_filename in files:
         view = sublime.active_window().active_view()
 
+        is_auto_indent = view.settings().get('auto_indent')
+
         if PY3:
-            view.run_command('insert', {
-                'characters': gist['files'][gist_filename]['content'],
+            if is_auto_indent == True:
+                view.settings().set('auto_indent',False)
+                view.run_command('insert', {
+                    'characters': gist['files'][gist_filename]['content'],
+                })
+                view.settings().set('auto_indent',True)
+            else:
+                view.run_command('insert', {
+                    'characters': gist['files'][gist_filename]['content'],
                 })
         else:
             edit = view.begin_edit()


### PR DESCRIPTION
This fixes the odd auto_indent issue when inserting gist - https://github.com/condemil/Gist/issues/124
I'm not a python coder so this may need to be reviewed by someone more knowledgeable.
Works on ST3 - Windows 7 64bit
