### PR TITLE
Move gist_title function call after condition

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -65,10 +65,10 @@ def gists_filter(all_gists):
     gists_names = []
 
     for gist in all_gists:
-        name = gist_title(gist)
-
         if not gist['files']:
             continue
+
+        name = gist_title(gist)
 
         if prefix:
             if name[0][0:prefix_len] == prefix:


### PR DESCRIPTION
When running 'Gist: Open Gist' from the Sublime Text Command Palette I get an error:
"error: Gist: unknown error (please, report a bug!)"
The console shows a 'IndexError: list index out of range' on line 46.

This happens when a gist contains no files, which is not possible through github.com, but it IS possible with this plugin by opening a Gist and choosing 'Gist: Delete Gist File' from the Command Palette.

The proposed fix ensures gist_title is not called unless the gist has 'files'.
