### PR TITLE
Added git-io.py

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -4,5 +4,6 @@
 	{ "keys": ["ctrl+k", "ctrl+s"], "command": "gist_update_file" },
 	{ "keys": ["ctrl+k", "ctrl+o"], "command": "gist_list" },
 	{ "keys": ["ctrl+k", "ctrl+["], "command": "insert_gist_list" },
-	{ "keys": ["ctrl+k", "ctrl+]"], "command": "gist_add_file" }
+	{ "keys": ["ctrl+k", "ctrl+]"], "command": "gist_add_file" },
+	{ "keys": ["ctrl+k", "ctrl+g"], "command": "gist_gitio" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,5 +4,6 @@
 	{ "keys": ["super+k", "super+s"], "command": "gist_update_file" },
 	{ "keys": ["super+k", "super+o"], "command": "gist_list" },
 	{ "keys": ["super+k", "super+["], "command": "insert_gist_list" },
-	{ "keys": ["super+k", "super+]"], "command": "gist_add_file" }
+	{ "keys": ["super+k", "super+]"], "command": "gist_add_file" },
+	{ "keys": ["super+k", "super+g"], "command": "gist_gitio" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -4,5 +4,6 @@
 	{ "keys": ["ctrl+k", "ctrl+s"], "command": "gist_update_file" },
 	{ "keys": ["ctrl+k", "ctrl+o"], "command": "gist_list" },
 	{ "keys": ["ctrl+k", "ctrl+["], "command": "insert_gist_list" },
-	{ "keys": ["ctrl+k", "ctrl+]"], "command": "gist_add_file" }
+	{ "keys": ["ctrl+k", "ctrl+]"], "command": "gist_add_file" },
+	{ "keys": ["ctrl+k", "ctrl+g"], "command": "sublime_gitio" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -5,5 +5,5 @@
 	{ "keys": ["ctrl+k", "ctrl+o"], "command": "gist_list" },
 	{ "keys": ["ctrl+k", "ctrl+["], "command": "insert_gist_list" },
 	{ "keys": ["ctrl+k", "ctrl+]"], "command": "gist_add_file" },
-	{ "keys": ["ctrl+k", "ctrl+g"], "command": "sublime_gitio" }
+	{ "keys": ["ctrl+k", "ctrl+g"], "command": "gist_gitio" }
 ]

--- a/Gist.sublime-commands
+++ b/Gist.sublime-commands
@@ -50,5 +50,9 @@
     {
         "caption": "Gist: Delete Gist",
         "command": "gist_delete"
+    },
+    {
+        "caption": "Gist: Shorten a GitHub.com URL",
+        "command": "gist_gitio"
     }
 ]

--- a/git-io.py
+++ b/git-io.py
@@ -1,0 +1,44 @@
+import sys
+PY3 = sys.version > '3'
+
+git_url = 'http://git.io/'
+caption = '[Enter a GitHub.com URL]  ' + b'\xe2\x96\x88'.decode('utf-8')
+url_msg = 'Git-io: Must be a GitHub.com URL.'
+err_msg = 'Git-io: Error contacting git.io'
+
+def git_io(req_url):
+    if PY3:
+        import urllib.request
+        urlopen = urllib.request.urlopen
+        data = bytes(
+            urllib.parse.urlencode(
+                {'url': req_url}
+            ), encoding='ascii'
+        )
+        URLError = urllib.error.HTTPError
+    else:
+        import urllib
+        urlopen = urllib.urlopen
+        data = urllib.urlencode({'url': req_url})
+        URLError = KeyError
+    try:
+        return urlopen(git_url, data).headers['location']
+    except URLError:
+        return url_msg
+    except:
+        return err_msg
+
+import sublime, sublime_plugin
+
+class SublimeGitioCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        self.view.window().show_input_panel(caption, '', self.on_done, None, None)
+
+    def on_done(self, req_url):
+        short_url = git_io(req_url)
+        if short_url in (url_msg, err_msg):
+            sublime.error_message(short_url)
+            self.view.window().show_input_panel(caption, req_url, self.on_done, None, None)
+        else:
+            sublime.set_clipboard(short_url)
+            sublime.status_message('Git-io: Copied to Clipboard! ' + short_url)

--- a/git-io.py
+++ b/git-io.py
@@ -3,8 +3,8 @@ PY3 = sys.version > '3'
 
 git_url = 'http://git.io/'
 caption = '[Enter a GitHub.com URL]  ' + b'\xe2\x96\x88'.decode('utf-8')
-url_msg = 'Git-io: Must be a GitHub.com URL.'
-err_msg = 'Git-io: Error contacting git.io'
+url_msg = 'Gist: Must be a GitHub.com URL.'
+err_msg = 'Gist: Error contacting git.io'
 
 def git_io(req_url):
     if PY3:
@@ -41,4 +41,4 @@ class GistGitioCommand(sublime_plugin.TextCommand):
             self.view.window().show_input_panel(caption, req_url, self.on_done, None, None)
         else:
             sublime.set_clipboard(short_url)
-            sublime.status_message('Git-io: Copied to Clipboard! ' + short_url)
+            sublime.status_message('Gist: Copied to Clipboard! ' + short_url)

--- a/git-io.py
+++ b/git-io.py
@@ -30,7 +30,7 @@ def git_io(req_url):
 
 import sublime, sublime_plugin
 
-class SublimeGitioCommand(sublime_plugin.TextCommand):
+class GistGitioCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         self.view.window().show_input_panel(caption, '', self.on_done, None, None)
 


### PR DESCRIPTION
GitHub.com URLs can now be shortened directly using git-io.py
Changes are made to keymap files and Gist.sublime-commands file regarding the same.
Added command was gist_gitio.
